### PR TITLE
Fix gFunc.EvaluateLevels never finding priority sets

### DIFF
--- a/addons/luashitacast/func.lua
+++ b/addons/luashitacast/func.lua
@@ -301,7 +301,7 @@ end
 
 local EvaluateLevels = function(baseTable, level)
     for name,set in pairs(baseTable) do
-        if (#name > 9) and (string.sub(name, #name - 9) == '_Priority') then
+        if (#name > 9) and (string.sub(name, -9) == '_Priority') then
             local newSet = {};
             for slotName,slotEntries in pairs(set) do
                 if (gData.Constants.EquipSlots[slotName] ~= nil) then
@@ -321,7 +321,7 @@ local EvaluateLevels = function(baseTable, level)
                     end
                 end
             end
-            local newKey = string.sub(name, 1, #name - 10);
+            local newKey = string.sub(name, 1, -10);
             baseTable[newKey] = newSet;
         end
     end


### PR DESCRIPTION
The string.sub command was grabbing the 10 last characters, instead of the intended 9, of the set names to compare to '_Priority' and so never evaluated to true. The same problem existed when assigning the name minus '_Priority' to the new set. This is fixed by using negative indexes to count back 9 and 10 characters from the end of the string respectively.