### PR TITLE
Added support for gear swap on helm action.

### DIFF
--- a/addons/luashitacast/data.lua
+++ b/addons/luashitacast/data.lua
@@ -409,6 +409,11 @@ data.GetAction = function()
         actionTable.Id = action.Resource.Id;
         actionTable.Name = action.Resource.Name[1];
         actionTable.Recast = action.Resource.RecastDelay * 250;
+    elseif (action.Type == 'TradeItem') then
+        actionTable.CastTime = action.Resource.CastTime * 250;
+        actionTable.Id = action.Resource.Id;
+        actionTable.Name = action.Resource.Name[1];
+        actionTable.Recast = action.Resource.RecastDelay * 250;
     end
 
     return actionTable;

--- a/addons/luashitacast/filetools.lua
+++ b/addons/luashitacast/filetools.lua
@@ -39,6 +39,7 @@ local CreateProfile = function(path)
     file:write('profile.HandleDefault = function()\nend\n\n');
     file:write('profile.HandleAbility = function()\nend\n\n');
     file:write('profile.HandleItem = function()\nend\n\n');
+    file:write('profile.HandleHelm = function()\nend\n\n');
     file:write('profile.HandlePrecast = function()\nend\n\n');
     file:write('profile.HandleMidcast = function()\nend\n\n');
     file:write('profile.HandlePreshot = function()\nend\n\n');

--- a/addons/luashitacast/packethandlers.lua
+++ b/addons/luashitacast/packethandlers.lua
@@ -230,6 +230,46 @@ packethandlers.HandleItemPacket = function(packet)
     gState.Inject(0x37, gState.PlayerAction.Packet);
 end
 
+packethandlers.HandleItemTradePacket = function(packet)
+
+	local itemCount = struct.unpack('B', packet, 0x3C + 0x01);
+	
+	if(itemCount == 1) then 
+		local targetIndex = struct.unpack('H', packet, 0x3A + 0x01);
+		local npcId = struct.unpack('H', packet, 0x04 + 0x01);
+		local itemIndex = struct.unpack('B', packet, 0x30 + 0x01);
+		local itemContainer = 0;
+		local item = AshitaCore:GetMemoryManager():GetInventory():GetContainerItem(itemContainer, itemIndex);
+
+		if (item == nil) or (item.Id == 0) or (item.Count == 0) then
+			gState.PlayerAction.Completion = os.clock() + gSettings.ItemBase + gSettings.ItemOffset;
+		else
+			gState.DelayedEquip = {};
+			gState.PlayerAction = { Block = false };
+			gState.PlayerAction.Packet = packet:totable();
+			gState.PlayerAction.Target = targetIndex;
+			gState.PlayerAction.Type = 'TradeItem';
+
+			gState.PlayerAction.Resource = AshitaCore:GetResourceManager():GetItemById(item.Id);
+			gState.PlayerAction.Completion = os.clock() + (gState.PlayerAction.Resource.CastTime * 0.25) + gSettings.ItemOffset;
+			
+			local itemname = gState.PlayerAction.Resource.Name[1];
+			if (itemname == 'Hatchet') or (itemname == 'Pickaxe') or (itemname == 'Sickle') then
+			
+				gState.HandleEquipEvent('HandleHelm', 'auto');
+			end
+		end 
+		
+		if (gState.PlayerAction.Block == true) then
+			gState.PlayerAction = nil;
+			return;
+		end
+		
+		gState.Inject(0x36, gState.PlayerAction.Packet);
+	end 
+end
+
+
 packethandlers.HandleOutgoingChunk = function(e)
     --Clear expired actions.
     local time = os.clock();
@@ -259,7 +299,9 @@ packethandlers.HandleOutgoingChunk = function(e)
         elseif (id == 0x15) then
             newPositionX = struct.unpack('f', e.chunk_data, offset + 0x04 + 1);
             newPositionY = struct.unpack('f', e.chunk_data, offset + 0x0C + 1);
-        elseif (id == 0x37) then
+        elseif (id == 0x36) then
+            gPacketHandlers.HandleItemTradePacket(struct.unpack('c' .. size, e.chunk_data, offset + 1));
+		elseif (id == 0x37) then
             gPacketHandlers.HandleItemPacket(struct.unpack('c' .. size, e.chunk_data, offset + 1));
         end
         offset = offset + size;
@@ -302,7 +344,10 @@ packethandlers.HandleOutgoingPacket = function(e)
             if (e.id == 0x1A) then
                 gPacketHandlers.HandleActionPacket(struct.unpack('c' .. e.size, e.data, 1));
                 e.blocked = true;
-            elseif (e.id == 0x37) then
+            elseif (e.id == 0x36) then
+                gPacketHandlers.HandleItemTradePacket(struct.unpack('c' .. e.size, e.data, 1));
+                e.blocked = true;
+			elseif (e.id == 0x37) then
                 gPacketHandlers.HandleItemPacket(struct.unpack('c' .. e.size, e.data, 1));
                 e.blocked = true;
             end
@@ -317,7 +362,7 @@ packethandlers.HandleOutgoingPacket = function(e)
 
     --Block all action and item packets that aren't injected.
     --HandleOutgoingChunk will automatically reinject them if keeping them.
-    if (e.id == 0x1A) or (e.id == 0x37) then
+    if (e.id == 0x1A) or (e.id == 0x36) or (e.id == 0x37) then
         e.blocked = true;
         return;
     end


### PR DESCRIPTION
Since the Item use pack 0x37 doesn't fire when not used on yourself as it is considered a trade to an NPC in 0x36 when you use an item on something else. *ie.. selbina fame trades*

I wanted the ability to swap in field gear when I use a logging macro, so I added support for helm swaps. 

in game macro: 
/item "Hatchet" <stnpc>

/lac profile section
profile.HandleHelm = function()
	gFunc.EquipSet(sets.logging);
end 

/lac set
['logging'] = {
        Body = 'Field Tunica',
        Hands = 'Field Gloves',
        Legs = 'Field Hose',
        Feet = 'Field Boots',
    }, 
